### PR TITLE
on completed torrent close button fix

### DIFF
--- a/app/download.js
+++ b/app/download.js
@@ -114,7 +114,7 @@ $(() => {
 
     function onCloseButtonPress() {
         win.setProgressBar(0, {mode: "normal"});
-        if(!paused){client.remove(client.torrents[0]);}
+        if(!paused && client.torrents[0]){client.remove(client.torrents[0]);}
         win.loadFile('./app/cancel.html')
     }
 


### PR DESCRIPTION
# problem
The close button threw an Exception which stated, that there was no torrent which could be removed by the client. That means that we tried to remove a torrent which doesn't even exist anymore.

# Solution
Since the torrent gets destroyed in the 'done' event, we have to check if that torrent does even exist before trying to remove it.

So in `download.js` a simple
```javascript
if(!paused && client.torrents[0]){client.remove(client.torrents[0]);}
```
instead of
```javascript
if(!paused){client.remove(client.torrents[0]);}
```

fixes the issue #10.